### PR TITLE
Pet and Spawn tweaks

### DIFF
--- a/datatype/_pet.lua
+++ b/datatype/_pet.lua
@@ -12,6 +12,9 @@
 ---@field Taunt fun(): boolean Taunt state
 ---@field Focus fun(): boolean Focus state
 ---@field ID fun(): integer returns pet ID
+---@field Name fun(): string Name
+---@field CleanName fun(): string The "cleaned up" name
+---@field Height fun(): integer Height
 local pet = {}
 
 ---Returns the slot number for the buff name

--- a/datatype/_spawn.lua
+++ b/datatype/_spawn.lua
@@ -14,6 +14,7 @@
 --- @field public Binding fun(): boolean Binding wounds?
 --- @field public Blind fun(): number Blind?  Not sure why this is a number?
 --- @field public Body body Body type
+--- @field public Buff fun(name: string): string
 --- @field public bShowHelm fun(): boolean Showing Helm?
 --- @field public bStationary fun(): boolean Stationary spawn?  Not to be confused with "Moving"
 --- @field public bTempPet fun(): boolean Is the spawn a Temporary Pet?


### PR DESCRIPTION
Added Name, CleanName and Height to the Pet TLO.

I am not 100% this is the way to go. Pet is a `spawn` underlying, and should maybe map directly to that datatype instead?
There is some functions declared for pet that is not in spawn: https://github.com/johnfking/mq-definitions/blob/35d9e7d1d9f94e649a79116398efaa110912ac17/datatype/_pet.lua#L17-L35

For Spawn, add Buff()